### PR TITLE
Update NixOS Wiki link

### DIFF
--- a/posts/2023-05-12-install-nixos-on-a-raspberry-pi.md
+++ b/posts/2023-05-12-install-nixos-on-a-raspberry-pi.md
@@ -18,7 +18,7 @@ always obvious how all the parts should fit together.
 
 # Install NixOS
 
-Follow the [Official NixOS on Raspberry Pi wiki](https://nixos.wiki/wiki/NixOS_on_ARM/Raspberry_Pi).
+Follow the [Official NixOS on Raspberry Pi wiki](https://wiki.nixos.org/wiki/NixOS_on_ARM/Raspberry_Pi).
 You should be able to download a pre-built image through Hydra which was nice. The guide will walk
 you through writing the image to a SD card and booting up the PI for the first time.
 

--- a/posts/2023-05-15-declarative-wi-fi-with-encrypted-secret-on-nix-os.md
+++ b/posts/2023-05-15-declarative-wi-fi-with-encrypted-secret-on-nix-os.md
@@ -26,11 +26,11 @@ the configuration:
 2. and the passphrase will be stored in the git repo you use to manage your deploy.
 
 The solution to the first issue is to use something like the `deployment.keys` option that is
-supported by most [deployment tools](https://nixos.wiki/wiki/Applications#Deployment).
+supported by most [deployment tools](https://wiki.nixos.org/wiki/Applications#Deployment).
 
 The solution to the second issue is to encrypt the secret in the repo, and decrypt it on the target
 machine, after deploy. [Multiple
-tools](https://nixos.wiki/wiki/Comparison_of_secret_managing_schemes) exist to handle this.
+tools](https://wiki.nixos.org/wiki/Comparison_of_secret_managing_schemes) exist to handle this.
 
 In this post, we will use [sops-nix](https://github.com/Mic92/sops-nix) which provides a solution
 for both issues.

--- a/posts/2023-07-02-backup-home-assistant-with-and-without-nix.md
+++ b/posts/2023-07-02-backup-home-assistant-with-and-without-nix.md
@@ -71,7 +71,7 @@ services.home-assistant = {
 };
 ```
 
-Note that I [combine declarative and UI defined automations](https://nixos.wiki/wiki/Home_Assistant#Combine_declarative_and_UI_defined_automations).
+Note that I [combine declarative and UI defined automations](https://wiki.nixos.org/wiki/Home_Assistant#Combine_declarative_and_UI_defined_automations).
 
 # Allow backup user to access Home Assistant backup folder
 

--- a/posts/2023-11-08-switch-to-colmena-for-local-deploys.markdown
+++ b/posts/2023-11-08-switch-to-colmena-for-local-deploys.markdown
@@ -71,7 +71,7 @@ Also, everything is explained in the `sops-nix` repo's readme file.
 
 The issue here is we can't use `nixos-rebuild` to deploy keys with `sops-nix` or any other key
 management system. You need to switch to `nixops`, `colmena` or any other such deploy system listed
-[here](https://nixos.wiki/wiki/Applications#Deployment).
+[here](https://wiki.nixos.org/wiki/Applications#Deployment).
 
 # Switching From Nixos-Rebuild to Colmena
 

--- a/posts/2024-02-09-zfs-on-nix-os.markdown
+++ b/posts/2024-02-09-zfs-on-nix-os.markdown
@@ -284,7 +284,7 @@ $ sudo zfs load-key data
 $ sudo zfs mount -a
 ```
 
-There are ways to automate this like [remote unlocking](https://nixos.wiki/wiki/ZFS#Remote_unlock).
+There are ways to automate this like [remote unlocking](https://wiki.nixos.org/wiki/ZFS#Remote_unlock).
 
 ## Next
 


### PR DESCRIPTION
Hello there 👋!

The NixOS wiki is in the process of migrating from https://nixos.wiki to https://wiki.nixos.org.
You can find more information about it [here](https://github.com/NixOS/foundation/issues/113).

You seem to be using the old link in your repository, which is why we send you this PR.
If you feel like this is not correct or have any questions, feel free to [get in touch with us](https://github.com/NixOS/nixos-wiki-infra/issues/105).


Have a great day,

-- The NixOS Wiki-Team ❄️